### PR TITLE
Fix syntax highlighting in issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -8,6 +8,6 @@ Please delete these instructions after you have read them.
 
 Brief description of the problem or desired feature.
 
-```{r}
+```r
 # insert reprex here
 ```


### PR DESCRIPTION
`{r}` is not interpreted as a valid language by GitHub flavoured markdown (hence no syntax highlighting), but simple `r` is.